### PR TITLE
Avoid calling is_callable if not necessary

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -174,7 +174,7 @@ class Assert {
 			return true;
 		}
 
-		if ( is_callable( $value ) && in_array( 'callable', $allowedTypes ) ) {
+		if ( in_array( 'callable', $allowedTypes ) && is_callable( $value ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Do the cheaper in_array() check beforehand.
is_callable can trigger things like autoloading, so it should only be called if necessary.