### PR TITLE
Require PHP >=5.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
             "name":         "Daniel Kinzler"
         }
     ],
-
+	"require": {
+		"php": ">=5.3.0"
+	},
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },
-
     "autoload": {
         "psr-4": {
             "Wikimedia\\Assert\\": "src/",
             "Wikimedia\\Assert\\Test\\": "tests/phpunit/"
         }
     }
-
 }


### PR DESCRIPTION
Must be 5.3 because of namespaces. No 5.5 features are currently used in this component.